### PR TITLE
Update Alpine version and disable Rust dependency as workaround to py…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.8-alpine3.11
+FROM python:3.8-alpine3.13
 
 WORKDIR /srv
 
 # Install system dependencies for: uWSGI, poetry, watchman
-RUn apk add --update --no-cache \
+RUN apk add --update --no-cache \
       gcc \
       libc-dev \
       libffi-dev \
@@ -28,6 +28,10 @@ RUn apk add --update --no-cache \
     #make && \
     #make install && \
     #cd .. && rm -rf watchman
+
+# cryptography module incompatibility with PEP517
+# https://github.com/pyca/cryptography/issues/5771
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
 # Install poetry
 RUN pip install poetry


### PR DESCRIPTION
…ca/cryptography#5771

## Changes
- Update Python Alpine base image version to `3.13` and disable Rust dependency that prevents cryptography from building.